### PR TITLE
Fps fix

### DIFF
--- a/uvc_camera/src/uvc_cam.cpp
+++ b/uvc_camera/src/uvc_cam.cpp
@@ -208,6 +208,8 @@ Cam::Cam(const char *_device, mode_t _mode, int _width, int _height, int _fps)
   rb.memory = V4L2_MEMORY_MMAP;
   if (ioctl(fd, VIDIOC_REQBUFS, &rb) < 0)
     throw std::runtime_error("unable to allocate buffers");
+  if (NUM_BUFFER != rb.count)
+    ROS_WARN("asked for %d buffers, got %d\r\n", NUM_BUFFER, rb.count);
   for (unsigned i = 0; i < NUM_BUFFER; i++)
   {
     memset(&buf, 0, sizeof(buf));


### PR DESCRIPTION
These 3 patches fix some minor annoying compatibility with the v4l2 subsystem.  This makes uvc_cam work with bttv based capture cards (and probably many more).  There were 2 bugs:  First, not all v4l2 devices support changing (or even querying) the framerate, so that ioctl failing is not an error. Second, some drivers  (bttv specifically) expect that mmaped image buffers are maped read and write.

-James
