### PR TITLE
Support MJPEG format direct streaming

### DIFF
--- a/uvc_camera/include/uvc_camera/camera.h
+++ b/uvc_camera/include/uvc_camera/camera.h
@@ -11,6 +11,7 @@ class Camera {
     Camera(ros::NodeHandle comm_nh, ros::NodeHandle param_nh);
     void onInit();
     void sendInfo(sensor_msgs::ImagePtr &image, ros::Time time);
+    void sendInfoJpeg(ros::Time time);
     void feedImages();
     ~Camera();
 
@@ -20,12 +21,13 @@ class Camera {
     bool ok;
 
     int width, height, fps, skip_frames, frames_to_skip;
-    std::string device, frame;
+    std::string device, frame, format;
     bool rotate;
 
     camera_info_manager::CameraInfoManager info_mgr;
 
     image_transport::Publisher pub;
+    ros::Publisher pubjpeg;
     ros::Publisher info_pub;
 
     uvc_cam::Cam *cam;


### PR DESCRIPTION
Currently uvc_camera crashes with MODE_MJPEG set up. This patch sends MJPEG frames from camera to wire directly without processing. The patch is tested OK with a Logitech B910 in ROS environment:

```
rosrun image_view image_view image:=/image_raw _image_transport:=compressed
```
