### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/uvc_camera/src/nodelets.cpp
+++ b/uvc_camera/src/nodelets.cpp
@@ -49,6 +49,6 @@ class StereoNodelet : public nodelet::Nodelet {
 
 };
 
-PLUGINLIB_DECLARE_CLASS(uvc_camera, CameraNodelet, uvc_camera::CameraNodelet, nodelet::Nodelet);
-PLUGINLIB_DECLARE_CLASS(uvc_camera, StereoNodelet, uvc_camera::StereoNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(uvc_camera::CameraNodelet, nodelet::Nodelet)
+PLUGINLIB_EXPORT_CLASS(uvc_camera::StereoNodelet, nodelet::Nodelet)
 


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions